### PR TITLE
Add type assertion to stdout IsTerminal() check

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -36,7 +36,9 @@ func NewSpinner(title string) *Spinner {
 		FrameRate: DEFAULT_FRAME_RATE,
 		runChan:   make(chan struct{}),
 	}
-	if !terminal.IsTerminal(syscall.Stdout) {
+	var stdout interface{} = syscall.Stdout
+	stdoutFD, ok := stdout.(int)
+	if !(ok && terminal.IsTerminal(stdoutFD)) {
 		sp.NoTty = true
 	}
 	return sp


### PR DESCRIPTION
Supports Windows cross-compilation, fixes #2. (Slightly uglier than I was hoping since under Linux/macOS `syscall.Stdout` is an `int`, and you can only make type assertions on interface types.)