### PR TITLE
Fix an issue where the spinner continues past its termination.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-spinner
+module github.com/janeczku/go-spinner
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module go-spinner
+
+go 1.15
+
+require golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/janeczku/go-spinner
+module github.com/elisarver/go-spinner
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/spinner.go
+++ b/spinner.go
@@ -82,17 +82,20 @@ func (sp *Spinner) Stop() {
 func (sp *Spinner) animate() {
 	var out string
 	for i := 0; i < len(sp.Charset); i++ {
-		out = sp.Charset[i] + " " + sp.Title
-		switch {
-		case sp.Output != nil:
-			fmt.Fprint(sp.Output, out)
-			//fmt.Fprint(sp.Output, "\r"+out)
-		case !sp.NoTty:
-			fmt.Print(out)
-			//fmt.Print("\r" + out)
+		select {
+		case <-sp.runChan:
+			return
+		default:
+			out = sp.Charset[i] + " " + sp.Title
+			switch {
+			case sp.Output != nil:
+				fmt.Fprint(sp.Output, out)
+			case !sp.NoTty:
+				fmt.Print(out)
+			}
+			time.Sleep(sp.FrameRate)
+			sp.clearLine()
 		}
-		time.Sleep(sp.FrameRate)
-		sp.clearLine()
 	}
 }
 

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -2,7 +2,7 @@ package spinner_test
 
 import (
 	"bytes"
-	spinner "go-spinner"
+	spinner "github.com/elisarver/go-spinner"
 	"testing"
 	"time"
 )

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -1,0 +1,33 @@
+package spinner_test
+
+import (
+	"bytes"
+	spinner "go-spinner"
+	"testing"
+	"time"
+)
+
+func TestSynch(t *testing.T) {
+			var out bytes.Buffer
+			sp := spinner.NewSpinner("Message1")
+			sp.Output = &out
+
+			sp2 := spinner.NewSpinner("Message2")
+			sp2.Output = &out
+
+			sp.Start()
+			time.Sleep(2 * time.Second)
+			sp.Stop()
+
+			sp2.Start()
+			time.Sleep(2 * time.Second)
+			sp2.Stop()
+
+			got := out.String()
+			want := "| Message1/ Message1- Message1\\ Message1| Message1/ Message1- Message1\\ Message1| Message1/ Message1- Message1\\ Message1| Message1/ Message1| Message2/ Message2- Message2\\ Message2| Message2/ Message2- Message2\\ Message2| Message2/ Message2- Message2\\ Message2| Message2/ Message2"
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+}
+
+


### PR DESCRIPTION
This change adds the channel-close handler inside the animate loop so that it doesn't have to wait for a full cycle to exit.

This was causing a jumble of spinner prompts when used in something we developed with the library.